### PR TITLE
fix: aceita nascimento opcional de cliente

### DIFF
--- a/__tests__/middlewares/validateClient.test.js
+++ b/__tests__/middlewares/validateClient.test.js
@@ -73,6 +73,30 @@ describe('validateClient Middleware', () => {
     expect(response.body.body).toHaveProperty('email', null);
   });
 
+  it('deve permitir telefone e data de nascimento omitidos', async () => {
+    const { phone, birthDate, ...payloadWithoutOptionalFields } = validPayload;
+
+    const response = await request(app)
+      .post('/client')
+      .send(payloadWithoutOptionalFields)
+      .expect(200);
+
+    expect(response.body).toHaveProperty('success', true);
+    expect(response.body.body).toHaveProperty('phone', null);
+    expect(response.body.body).toHaveProperty('birthDate', null);
+  });
+
+  it('deve permitir telefone e data de nascimento em branco', async () => {
+    const response = await request(app)
+      .post('/client')
+      .send({ ...validPayload, phone: '', birthDate: '' })
+      .expect(200);
+
+    expect(response.body).toHaveProperty('success', true);
+    expect(response.body.body).toHaveProperty('phone', null);
+    expect(response.body.body).toHaveProperty('birthDate', null);
+  });
+
   it('deve bloquear email invalido', async () => {
     if (jest.isMockFunction(validator.isEmail)) {
       validator.isEmail.mockReturnValueOnce(false);
@@ -100,6 +124,10 @@ describe('validateClient Middleware', () => {
   });
 
   it('deve bloquear telefone invalido', async () => {
+    if (jest.isMockFunction(isValidPhoneNumber)) {
+      isValidPhoneNumber.mockReturnValueOnce({ isValid: false, formatted: null });
+    }
+
     const response = await request(app)
       .post('/client')
       .send({ ...validPayload, phone: 'abc' })

--- a/__tests__/middlewares/validateClientUpdate.test.js
+++ b/__tests__/middlewares/validateClientUpdate.test.js
@@ -73,6 +73,30 @@ describe('validateClientUpdate Middleware', () => {
     expect(response.body.body).toHaveProperty('email', null);
   });
 
+  it('deve permitir telefone e data de nascimento omitidos', async () => {
+    const { phone, birthDate, ...payloadWithoutOptionalFields } = validPayload;
+
+    const response = await request(app)
+      .patch('/client/1')
+      .send(payloadWithoutOptionalFields)
+      .expect(200);
+
+    expect(response.body).toHaveProperty('success', true);
+    expect(response.body.body).toHaveProperty('phone', null);
+    expect(response.body.body).toHaveProperty('birthDate', null);
+  });
+
+  it('deve permitir telefone e data de nascimento em branco', async () => {
+    const response = await request(app)
+      .patch('/client/1')
+      .send({ ...validPayload, phone: '', birthDate: '' })
+      .expect(200);
+
+    expect(response.body).toHaveProperty('success', true);
+    expect(response.body.body).toHaveProperty('phone', null);
+    expect(response.body.body).toHaveProperty('birthDate', null);
+  });
+
   it('deve bloquear email invalido quando preenchido', async () => {
     if (jest.isMockFunction(validator.isEmail)) {
       validator.isEmail.mockReturnValueOnce(false);
@@ -89,6 +113,32 @@ describe('validateClientUpdate Middleware', () => {
   it('deve bloquear email ja existente para usuario', async () => {
     if (jest.isMockFunction(Client.findOne)) {
       Client.findOne.mockResolvedValueOnce({ id: 2 });
+    }
+
+    const response = await request(app)
+      .patch('/client/1')
+      .send(validPayload)
+      .expect(400);
+
+    expect(response.body).toHaveProperty('error');
+  });
+
+  it('deve bloquear telefone invalido quando preenchido', async () => {
+    if (jest.isMockFunction(isValidPhoneNumber)) {
+      isValidPhoneNumber.mockReturnValueOnce({ isValid: false, formatted: null });
+    }
+
+    const response = await request(app)
+      .patch('/client/1')
+      .send({ ...validPayload, phone: 'abc' })
+      .expect(400);
+
+    expect(response.body).toHaveProperty('error');
+  });
+
+  it('deve bloquear data invalida quando preenchida', async () => {
+    if (jest.isMockFunction(validator.isDate)) {
+      validator.isDate.mockReturnValueOnce(false);
     }
 
     const response = await request(app)

--- a/src/middlewares/validateClient.js
+++ b/src/middlewares/validateClient.js
@@ -5,22 +5,28 @@ import { existingClient } from '../utils/emailValidator.js';
 const validateClient = async (req, res, next) => {
   const { email, name, phone, birthDate } = req.body;
   const userId = req.user?.id;
+  const normalizedName = typeof name === 'string' ? name.trim() : name;
   const normalizedEmail = typeof email === 'string' ? email.trim() : email;
+  const normalizedPhone = typeof phone === 'string' ? phone.trim() : phone;
+  const normalizedBirthDate = typeof birthDate === 'string' ? birthDate.trim() : birthDate;
   const hasEmail = typeof normalizedEmail === 'string' && normalizedEmail.length > 0;
+  const hasPhone = typeof normalizedPhone === 'string' && normalizedPhone.length > 0;
+  const hasBirthDate = typeof normalizedBirthDate === 'string' && normalizedBirthDate.length > 0;
 
+  req.body.name = normalizedName;
   req.body.email = hasEmail ? normalizedEmail : null;
+  req.body.phone = hasPhone ? normalizedPhone : null;
+  req.body.birthDate = hasBirthDate ? normalizedBirthDate : null;
 
   const emailExists = hasEmail ? await existingClient(normalizedEmail, null, userId) : false;
 
   const validations = [
-    { condition: !name, message: "É necessário fornecer o nome para finalizar o registro." },
-    { condition: !phone, message: "É necessário fornecer o número de telefone para finalizar o registro." },
-    { condition: !birthDate, message: "É necessário fornecer a data de nascimento para finalizar o registro." },
+    { condition: !normalizedName, message: "É necessário fornecer o nome para finalizar o registro." },
     { condition: hasEmail && !validator.isEmail(normalizedEmail), message: "E-mail inválido." },
     { condition: emailExists, message: "Já existe um cliente com este e-mail." },
-    { condition: phone && !isValidPhoneNumber(phone).isValid, message: "Número de telefone inválido." },
-    { condition: !validator.isDate(birthDate, { format: 'YYYY-MM-DD', strictMode: true }), message: "Data de nascimento inválida. Use o formato YYYY-MM-DD." },
-    { condition: new Date(birthDate) > new Date(), message: "Data de nascimento não pode ser no futuro." }
+    { condition: hasPhone && !isValidPhoneNumber(normalizedPhone).isValid, message: "Número de telefone inválido." },
+    { condition: hasBirthDate && !validator.isDate(normalizedBirthDate, { format: 'YYYY-MM-DD', strictMode: true }), message: "Data de nascimento inválida. Use o formato YYYY-MM-DD." },
+    { condition: hasBirthDate && new Date(normalizedBirthDate) > new Date(), message: "Data de nascimento não pode ser no futuro." }
   ];
 
   const error = validations.find((v) => v.condition);

--- a/src/middlewares/validateClientUpdate.js
+++ b/src/middlewares/validateClientUpdate.js
@@ -5,22 +5,28 @@ import { existingClient } from '../utils/emailValidator.js';
 const validateClientUpdate = async (req, res, next) => {
   const { email, name, phone, birthDate } = req.body;
   const userId = req.user?.id;
+  const normalizedName = typeof name === 'string' ? name.trim() : name;
   const normalizedEmail = typeof email === 'string' ? email.trim() : email;
+  const normalizedPhone = typeof phone === 'string' ? phone.trim() : phone;
+  const normalizedBirthDate = typeof birthDate === 'string' ? birthDate.trim() : birthDate;
   const hasEmail = typeof normalizedEmail === 'string' && normalizedEmail.length > 0;
+  const hasPhone = typeof normalizedPhone === 'string' && normalizedPhone.length > 0;
+  const hasBirthDate = typeof normalizedBirthDate === 'string' && normalizedBirthDate.length > 0;
 
+  req.body.name = normalizedName;
   req.body.email = hasEmail ? normalizedEmail : null;
+  req.body.phone = hasPhone ? normalizedPhone : null;
+  req.body.birthDate = hasBirthDate ? normalizedBirthDate : null;
 
   const emailExists = hasEmail ? await existingClient(normalizedEmail, req.params.id, userId) : false;
 
   const validations = [
-    { condition: !name, message: "É necessário fornecer o nome para finalizar o registro." },
-    { condition: !phone, message: "É necessário fornecer o número de telefone para finalizar o registro." },
-    { condition: !birthDate, message: "É necessário fornecer a data de nascimento para finalizar o registro." },
+    { condition: !normalizedName, message: "É necessário fornecer o nome para finalizar o registro." },
     { condition: hasEmail && !validator.isEmail(normalizedEmail), message: "E-mail inválido." },
     { condition: emailExists, message: "Já existe um cliente com este e-mail." },
-    { condition: phone && !isValidPhoneNumber(phone).isValid, message: "Número de telefone inválido." },
-    { condition: !validator.isDate(birthDate, { format: 'YYYY-MM-DD', strictMode: true }), message: "Data de nascimento inválida. Use o formato YYYY-MM-DD." },
-    { condition: new Date(birthDate) > new Date(), message: "Data de nascimento não pode ser no futuro." }
+    { condition: hasPhone && !isValidPhoneNumber(normalizedPhone).isValid, message: "Número de telefone inválido." },
+    { condition: hasBirthDate && !validator.isDate(normalizedBirthDate, { format: 'YYYY-MM-DD', strictMode: true }), message: "Data de nascimento inválida. Use o formato YYYY-MM-DD." },
+    { condition: hasBirthDate && new Date(normalizedBirthDate) > new Date(), message: "Data de nascimento não pode ser no futuro." }
   ];
 
   const error = validations.find((v) => v.condition);


### PR DESCRIPTION
## O que mudou
- Permite cadastrar/editar cliente sem telefone e sem data de nascimento.
- Normaliza telefone e nascimento vazios para null.
- Mantem validacao de telefone e nascimento quando os campos forem preenchidos.
- Adiciona cobertura focada para campos opcionais nos middlewares de cliente.

## Por que
O cadastro mobile passara a deixar nascimento opcional e digitavel; a API precisa aceitar ausencia real desse campo sem obrigar data default.

## Validacoes
- npm test -- --runTestsByPath __tests__/middlewares/validateClient.test.js __tests__/middlewares/validateClientUpdate.test.js
- git diff --check

Refs #23