### PR TITLE
Promover health check da API para produção

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.1.1 - 2026-07-16
+
+- Adiciona `GET /health` público e sem dependências externas para monitoramento da API.
+- Documenta a configuração de keep-alive no UptimeRobot para o deploy no Render.
+
 ## 1.1.0 - 2026-06-03
 
 - Adiciona integração Google Calendar mão única BeautyApp -> Google Calendar.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,35 @@ A API estará disponível em `http://localhost:3000`.
 
 ---
 
+## Monitoramento no Render
+
+A API disponibiliza um endpoint público e leve para health check:
+
+```http
+GET /health
+```
+
+Resposta esperada:
+
+```json
+{
+  "status": "ok"
+}
+```
+
+Para manter a instância gratuita do Render ativa durante a fase de MVP, configure
+um monitor HTTP no UptimeRobot com:
+
+- URL: `https://api-h1hk.onrender.com/health`
+- método: `GET`
+- intervalo: 5 minutos
+- resposta esperada: HTTP `200`
+
+O endpoint não consulta banco de dados nem integrações externas. Ele verifica
+somente se o processo HTTP da API está respondendo.
+
+---
+
 ## Contribuição
 
 O BeautyApp é um projeto privado, desenvolvido como parte do portfólio pessoal de seu criador Gabriel Ribeiro e com potencial para comercialização futura.

--- a/__tests__/integration/server.test.js
+++ b/__tests__/integration/server.test.js
@@ -7,6 +7,7 @@ import {
   serviceRoutes,
   appointmentRoutes,
   userRoutes,
+  healthRoutes,
 } from '../../src/routes/index.js';
 
 const app = express();
@@ -18,10 +19,19 @@ app.use('/clients', clientRoutes);
 app.use('/services', serviceRoutes);
 app.use('/appointments', appointmentRoutes);
 app.use('/users', userRoutes);
+app.use('/health', healthRoutes);
 
 const withAuth = (reqBuilder) => reqBuilder.set('Authorization', 'Bearer test-token');
 
 describe('Server Integration Tests', () => {
+  it('deve expor health check sem autenticacao', async () => {
+    const response = await request(app)
+      .get('/health')
+      .expect(200);
+
+    expect(response.body).toEqual({ status: 'ok' });
+  });
+
   it('deve configurar middleware JSON', async () => {
     const response = await request(app)
       .post('/auth/login')

--- a/__tests__/routes/healthRoutes.test.js
+++ b/__tests__/routes/healthRoutes.test.js
@@ -1,0 +1,17 @@
+import request from 'supertest';
+import express from 'express';
+import healthRoutes from '../../src/routes/healthRoutes.js';
+
+const app = express();
+app.use('/health', healthRoutes);
+
+describe('Health Routes', () => {
+  it('responde sem autenticacao e sem permitir cache', async () => {
+    const response = await request(app)
+      .get('/health')
+      .expect('Cache-Control', 'no-store')
+      .expect(200);
+
+    expect(response.body).toEqual({ status: 'ok' });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "api",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "api",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "ISC",
       "dependencies": {
         "bcrypt": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "description": "",
   "main": "index.js",

--- a/server.js
+++ b/server.js
@@ -9,6 +9,7 @@ import {
   appointmentRoutes,
   googleCalendarIntegrationRoutes,
   userRoutes,
+  healthRoutes,
 } from './src/routes/index.js';
 
 const app = express();
@@ -43,6 +44,7 @@ app.use('/services', serviceRoutes);
 app.use('/appointments', appointmentRoutes);
 app.use('/integrations/google-calendar', googleCalendarIntegrationRoutes);
 app.use('/users', userRoutes);
+app.use('/health', healthRoutes);
 
 const port = process.env.PORT || 3000;
 

--- a/src/routes/healthRoutes.js
+++ b/src/routes/healthRoutes.js
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+
+const router = Router();
+
+router.get('/', (_req, res) => {
+  res.set('Cache-Control', 'no-store');
+  return res.status(200).json({ status: 'ok' });
+});
+
+export default router;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -4,6 +4,7 @@ import serviceRoutes from './serviceRoutes.js';
 import appointmentRoutes from './appointmentRoutes.js';
 import googleCalendarIntegrationRoutes from './googleCalendarIntegrationRoutes.js';
 import userRoutes from './public/userRoutes.js';
+import healthRoutes from './healthRoutes.js';
 
 export {
   authRoutes,
@@ -12,4 +13,5 @@ export {
   appointmentRoutes,
   googleCalendarIntegrationRoutes,
   userRoutes,
+  healthRoutes,
 };


### PR DESCRIPTION
## Promoção para produção

Este PR promove para `master` a rota pública `GET /health`, os testes automatizados e a documentação do monitoramento pelo UptimeRobot.

## Conteúdo validado

- resposta `200` com `{ "status": "ok" }`;
- endpoint sem autenticação, banco ou integrações externas;
- cache desabilitado;
- API na versão `1.1.1`;
- 18 suítes e 91 testes aprovados.

Closes #32.