### PR TITLE
chore: promove arquivamento de cancelados

### DIFF
--- a/__tests__/controllers/appointment.test.js
+++ b/__tests__/controllers/appointment.test.js
@@ -15,8 +15,11 @@ app.use((req, res, next) => {
   next();
 });
 
+app.get('/appointments', AppointmentController.listAppointments);
 app.post('/appointments', AppointmentController.createAppointment);
 app.patch('/appointments/:id', AppointmentController.updateAppointment);
+app.patch('/appointments/:id/status', AppointmentController.updateAppointmentStatus);
+app.patch('/appointments/:id/archive', AppointmentController.archiveAppointment);
 
 const service = {
   id: 2,
@@ -34,6 +37,7 @@ const buildLoadedAppointment = (depositAmount, googleSyncStatus = 'disabled') =>
   price: service.price,
   depositAmount,
   status: 'scheduled',
+  archivedAt: null,
   notes: '',
   googleSyncStatus,
   googleEventId: null,
@@ -278,5 +282,69 @@ describe('AppointmentController', () => {
       }),
       expect.objectContaining({ where: { id: 10 } }),
     );
+  });
+
+  it('oculta agendamentos arquivados das listagens normais', async () => {
+    Appointment.findAll.mockResolvedValue([]);
+
+    await request(app)
+      .get('/appointments?from=2026-06-01T00:00:00.000Z&to=2026-06-02T00:00:00.000Z')
+      .expect(200);
+
+    expect(Appointment.findAll).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({
+        userId: 1,
+        archivedAt: null,
+      }),
+    }));
+  });
+
+  it('permite consulta autorizada com arquivados para historico', async () => {
+    Appointment.findAll.mockResolvedValue([]);
+
+    await request(app)
+      .get('/appointments?from=2026-06-01T00:00:00.000Z&to=2026-06-02T00:00:00.000Z&includeArchived=true')
+      .expect(200);
+
+    const [{ where }] = Appointment.findAll.mock.calls.at(-1);
+    expect(where).toEqual(expect.objectContaining({ userId: 1 }));
+    expect(where).not.toHaveProperty('archivedAt');
+  });
+
+  it('arquiva somente atendimento cancelado sem disparar sincronizacao Google', async () => {
+    const canceledAppointment = {
+      ...buildLoadedAppointment(0),
+      status: 'canceled',
+      archivedAt: null,
+    };
+    canceledAppointment.update = jest.fn(async (values) => Object.assign(canceledAppointment, values));
+    Appointment.findOne.mockResolvedValue(canceledAppointment);
+
+    const response = await request(app)
+      .patch('/appointments/10/archive')
+      .expect(200);
+
+    expect(canceledAppointment.update).toHaveBeenCalledWith({ archivedAt: expect.any(Date) });
+    expect(response.body).toEqual(expect.objectContaining({
+      id: 10,
+      status: 'canceled',
+      archivedAt: expect.any(String),
+    }));
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejeita arquivamento de atendimento que nao esta cancelado', async () => {
+    const scheduledAppointment = {
+      ...buildLoadedAppointment(0),
+      update: jest.fn(),
+    };
+    Appointment.findOne.mockResolvedValue(scheduledAppointment);
+
+    await request(app)
+      .patch('/appointments/10/archive')
+      .expect(409);
+
+    expect(scheduledAppointment.update).not.toHaveBeenCalled();
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/routes/appointmentRoutes.test.js
+++ b/__tests__/routes/appointmentRoutes.test.js
@@ -1,6 +1,7 @@
 ﻿import request from 'supertest';
 import express from 'express';
 import appointmentRoutes from '../../src/routes/appointmentRoutes.js';
+import Appointment from '../../src/models/Appointment.js';
 
 const app = express();
 app.use(express.json());
@@ -40,6 +41,37 @@ describe('Appointment Routes', () => {
       .patch('/appointments/1/status')
       .send({ status: 'canceled' }))
       .expect(404);
+  });
+
+  it('deve permitir arquivar atendimento cancelado autenticado', async () => {
+    const appointment = {
+      id: 1,
+      userId: 1,
+      clientId: 1,
+      serviceId: 1,
+      startAt: new Date('2026-04-15T14:00:00.000Z'),
+      endAt: new Date('2026-04-15T15:00:00.000Z'),
+      price: 100,
+      depositAmount: 0,
+      status: 'canceled',
+      archivedAt: null,
+      notes: '',
+      googleSyncStatus: 'disabled',
+      client: { id: 1, name: 'Ana' },
+      services: [],
+    };
+    appointment.update = jest.fn(async (values) => Object.assign(appointment, values));
+    Appointment.findOne.mockResolvedValue(appointment);
+
+    const response = await withAuth(request(app)
+      .patch('/appointments/1/archive'))
+      .expect(200);
+
+    expect(response.body).toEqual(expect.objectContaining({
+      id: 1,
+      status: 'canceled',
+      archivedAt: expect.any(String),
+    }));
   });
 
   it('deve retornar 401 sem token', async () => {

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -217,6 +217,11 @@ jest.mock('./src/controllers/appointment.js', () => ({
     createAppointment: jest.fn((req, res) => res.status(201).json({ id: 1 })),
     updateAppointment: jest.fn((req, res) => res.status(200).json({ id: 1 })),
     updateAppointmentStatus: jest.fn((req, res) => res.status(200).json({ id: 1, status: req.body.status })),
+    archiveAppointment: jest.fn((req, res) => res.status(200).json({
+      id: 1,
+      status: 'canceled',
+      archivedAt: new Date().toISOString(),
+    })),
   },
 }));
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "api",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "api",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
         "bcrypt": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "type": "module",
   "description": "",
   "main": "index.js",

--- a/src/controllers/appointment.js
+++ b/src/controllers/appointment.js
@@ -234,6 +234,7 @@ const toPayload = (appointment) => {
       ? Number(appointment.depositAmount)
       : 0,
     status: appointment.status,
+    archivedAt: appointment.archivedAt ? new Date(appointment.archivedAt).toISOString() : null,
     notes: appointment.notes || '',
     googleEventId: appointment.googleEventId || null,
     googleCalendarId: appointment.googleCalendarId || null,
@@ -247,6 +248,7 @@ const findConflict = async ({ userId, startAt, endAt, excludeId = null }) => {
   const where = {
     userId,
     status: { [Op.ne]: 'canceled' },
+    archivedAt: null,
     startAt: { [Op.lt]: endAt },
     endAt: { [Op.gt]: startAt },
   };
@@ -281,7 +283,7 @@ class AppointmentController {
   static async listAppointments(req, res) {
     try {
       const userId = AppointmentController.getUserId(req);
-      const { from, to } = req.query;
+      const { from, to, includeArchived } = req.query;
 
       const fromDate = parseUtcDate(from);
       const toDate = parseUtcDate(to);
@@ -290,12 +292,18 @@ class AppointmentController {
         return res.status(400).json({ error: 'Parametros from/to invalidos. Use ISO-8601 UTC.' });
       }
 
+      const where = {
+        userId,
+        startAt: { [Op.lt]: toDate },
+        endAt: { [Op.gt]: fromDate },
+      };
+
+      if (includeArchived !== 'true') {
+        where.archivedAt = null;
+      }
+
       const appointments = await Appointment.findAll({
-        where: {
-          userId,
-          startAt: { [Op.lt]: toDate },
-          endAt: { [Op.gt]: fromDate },
-        },
+        where,
         include: appointmentIncludes,
         order: [['startAt', 'ASC']],
       });
@@ -410,7 +418,7 @@ class AppointmentController {
       const userId = AppointmentController.getUserId(req);
       const { id } = req.params;
 
-      const appointment = await Appointment.findOne({ where: { id, userId } });
+      const appointment = await Appointment.findOne({ where: { id, userId, archivedAt: null } });
       if (!appointment) {
         return res.status(404).json({ error: 'Agendamento nao encontrado.' });
       }
@@ -518,7 +526,7 @@ class AppointmentController {
         return res.status(400).json({ error: `Status invalido. Use: ${ALLOWED_STATUS.join(', ')}` });
       }
 
-      const appointment = await Appointment.findOne({ where: { id, userId } });
+      const appointment = await Appointment.findOne({ where: { id, userId, archivedAt: null } });
       if (!appointment) {
         return res.status(404).json({ error: 'Agendamento nao encontrado.' });
       }
@@ -549,6 +557,32 @@ class AppointmentController {
     } catch (error) {
       console.error('Erro ao atualizar status:', error);
       return res.status(500).json({ error: 'Erro ao atualizar status do agendamento.' });
+    }
+  }
+
+  static async archiveAppointment(req, res) {
+    try {
+      const userId = AppointmentController.getUserId(req);
+      const { id } = req.params;
+      const appointment = await Appointment.findOne({ where: { id, userId } });
+
+      if (!appointment) {
+        return res.status(404).json({ error: 'Agendamento nao encontrado.' });
+      }
+
+      if (appointment.status !== 'canceled') {
+        return res.status(409).json({ error: 'Somente atendimentos cancelados podem ser removidos da agenda.' });
+      }
+
+      if (!appointment.archivedAt) {
+        await appointment.update({ archivedAt: new Date() });
+      }
+
+      const archived = await loadAppointmentWithRelations(appointment.id, userId);
+      return res.status(200).json(toPayload(archived));
+    } catch (error) {
+      console.error('Erro ao arquivar agendamento:', error);
+      return res.status(500).json({ error: 'Erro ao remover o agendamento da agenda.' });
     }
   }
 

--- a/src/migrations/20260722000100-add-archived-at-to-appointments.cjs
+++ b/src/migrations/20260722000100-add-archived-at-to-appointments.cjs
@@ -1,0 +1,19 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('appointments', 'archivedAt', {
+      type: Sequelize.DATE,
+      allowNull: true,
+    });
+
+    await queryInterface.addIndex('appointments', ['userId', 'archivedAt', 'startAt'], {
+      name: 'appointments_user_archived_start_idx',
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeIndex('appointments', 'appointments_user_archived_start_idx');
+    await queryInterface.removeColumn('appointments', 'archivedAt');
+  },
+};

--- a/src/models/Appointment.js
+++ b/src/models/Appointment.js
@@ -41,6 +41,10 @@ const Appointment = sequelize.define('Appointment', {
     allowNull: false,
     defaultValue: 'scheduled',
   },
+  archivedAt: {
+    type: DataTypes.DATE,
+    allowNull: true,
+  },
   notes: {
     type: DataTypes.TEXT,
     allowNull: true,

--- a/src/routes/appointmentRoutes.js
+++ b/src/routes/appointmentRoutes.js
@@ -10,6 +10,7 @@ router.get('/', AppointmentController.listAppointments);
 router.post('/', AppointmentController.createAppointment);
 router.patch('/:id', AppointmentController.updateAppointment);
 router.patch('/:id/status', AppointmentController.updateAppointmentStatus);
+router.patch('/:id/archive', AppointmentController.archiveAppointment);
 
 export default router;
 


### PR DESCRIPTION
## Promoção para master

Promove a entrega da API para ocultação persistente de atendimentos cancelados.

- PR de implementação: #38
- Issue da API: #37
- Issue do app: lBorD/BeautyApp#101
- Checkpoint de rollback anterior: checkpoint/api-before-BEAUTY-37-20260722 (7f4df873ea2279cdb55fc8c48a32c05c048a639f)
- Validação: 18 suítes e 100 testes aprovados.